### PR TITLE
Change requested_reviewers to reviewers and display only labels name

### DIFF
--- a/spec/__mocks__/github_reviewers_data.json
+++ b/spec/__mocks__/github_reviewers_data.json
@@ -1,0 +1,120 @@
+{
+  "data": [{
+      "id": 124545071,
+      "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTI0NTQ1MDcx",
+      "user": {
+        "login": "caiammm",
+        "id": 5641804,
+        "node_id": "MDQ6VXNlcjU2NDE4MDQ=",
+        "avatar_url": "https://avatars3.githubusercontent.com/u/5641804?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/caiammm",
+        "html_url": "https://github.com/caiammm",
+        "followers_url": "https://api.github.com/users/caiammm/followers",
+        "following_url": "https://api.github.com/users/caiammm/following{/other_user}",
+        "gists_url": "https://api.github.com/users/caiammm/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/caiammm/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/caiammm/subscriptions",
+        "organizations_url": "https://api.github.com/users/caiammm/orgs",
+        "repos_url": "https://api.github.com/users/caiammm/repos",
+        "events_url": "https://api.github.com/users/caiammm/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/caiammm/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "body": "",
+      "state": "APPROVED",
+      "html_url": "https://github.com/redealumni/quero_bolsa/pull/7000#pullrequestreview-124545071",
+      "pull_request_url": "https://api.github.com/repos/redealumni/quero_bolsa/pulls/7000",
+      "author_association": "COLLABORATOR",
+      "_links": {
+        "html": {
+          "href": "https://github.com/redealumni/quero_bolsa/pull/7000#pullrequestreview-124545071"
+        },
+        "pull_request": {
+          "href": "https://api.github.com/repos/redealumni/quero_bolsa/pulls/7000"
+        }
+      },
+      "submitted_at": "2018-05-30T18:54:00Z",
+      "commit_id": "dcee6b181ba4d4957602af740b437ad72abbb6f8"
+    },
+    {
+      "id": 124556429,
+      "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTI0NTU2NDI5",
+      "user": {
+        "login": "pufe",
+        "id": 5657967,
+        "node_id": "MDQ6VXNlcjU2NTc5Njc=",
+        "avatar_url": "https://avatars2.githubusercontent.com/u/5657967?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/pufe",
+        "html_url": "https://github.com/pufe",
+        "followers_url": "https://api.github.com/users/pufe/followers",
+        "following_url": "https://api.github.com/users/pufe/following{/other_user}",
+        "gists_url": "https://api.github.com/users/pufe/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/pufe/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/pufe/subscriptions",
+        "organizations_url": "https://api.github.com/users/pufe/orgs",
+        "repos_url": "https://api.github.com/users/pufe/repos",
+        "events_url": "https://api.github.com/users/pufe/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/pufe/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "body": "",
+      "state": "APPROVED",
+      "html_url": "https://github.com/redealumni/quero_bolsa/pull/7000#pullrequestreview-124556429",
+      "pull_request_url": "https://api.github.com/repos/redealumni/quero_bolsa/pulls/7000",
+      "author_association": "COLLABORATOR",
+      "_links": {
+        "html": {
+          "href": "https://github.com/redealumni/quero_bolsa/pull/7000#pullrequestreview-124556429"
+        },
+        "pull_request": {
+          "href": "https://api.github.com/repos/redealumni/quero_bolsa/pulls/7000"
+        }
+      },
+      "submitted_at": "2018-05-30T19:25:01Z",
+      "commit_id": "dcee6b181ba4d4957602af740b437ad72abbb6f8"
+    },
+    {
+      "id": 124601435,
+      "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTI0NjAxNDM1",
+      "user": {
+        "login": "Emerick94",
+        "id": 27729388,
+        "node_id": "MDQ6VXNlcjI3NzI5Mzg4",
+        "avatar_url": "https://avatars1.githubusercontent.com/u/27729388?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Emerick94",
+        "html_url": "https://github.com/Emerick94",
+        "followers_url": "https://api.github.com/users/Emerick94/followers",
+        "following_url": "https://api.github.com/users/Emerick94/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Emerick94/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Emerick94/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Emerick94/subscriptions",
+        "organizations_url": "https://api.github.com/users/Emerick94/orgs",
+        "repos_url": "https://api.github.com/users/Emerick94/repos",
+        "events_url": "https://api.github.com/users/Emerick94/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Emerick94/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "body": "",
+      "state": "APPROVED",
+      "html_url": "https://github.com/redealumni/quero_bolsa/pull/7000#pullrequestreview-124601435",
+      "pull_request_url": "https://api.github.com/repos/redealumni/quero_bolsa/pulls/7000",
+      "author_association": "COLLABORATOR",
+      "_links": {
+        "html": {
+          "href": "https://github.com/redealumni/quero_bolsa/pull/7000#pullrequestreview-124601435"
+        },
+        "pull_request": {
+          "href": "https://api.github.com/repos/redealumni/quero_bolsa/pulls/7000"
+        }
+      },
+      "submitted_at": "2018-05-30T21:31:24Z",
+      "commit_id": "dcee6b181ba4d4957602af740b437ad72abbb6f8"
+    }
+  ]
+}

--- a/spec/github/github_data.spec.js
+++ b/spec/github/github_data.spec.js
@@ -2,9 +2,11 @@ const fs = require('fs');
 
 const githubPullRequest = fs.readFileSync(__dirname + '/../__mocks__/github_pull_request_data.json', 'utf8');
 const githubPullRequestFiles = fs.readFileSync(__dirname + '/../__mocks__/github_pull_request_files_data.json', 'utf8');
+const githubReviewersDataFile = fs.readFileSync(__dirname + '/../__mocks__/github_reviewers_data.json', 'utf8');
 
 const githubPullRequestJson = JSON.parse(githubPullRequest);
 const githubPullRequestFilesJson = JSON.parse(githubPullRequestFiles);
+const githubReviewersDataJson = JSON.parse(githubReviewersDataFile);
 
 const githubDataParserFile = require(__dirname + '/../../src/github/github-data-parser.js');
 
@@ -20,7 +22,7 @@ test('Verify if the github files are correctly treated', () => {
       "number": 14,
       "owner": "quero-edu",
       "repo": "github-scraper",
-      "reviewers": "{\"reviewers\":[]}",
+      "reviewers": "{\"reviewers\":[\"caiammm\",\"pufe\",\"Emerick94\"]}",
       "title": "Change variabled to json",
       "user": "augusto-queirantes"
     },
@@ -31,5 +33,5 @@ test('Verify if the github files are correctly treated', () => {
   };
 
   expect(GithubDataParser).toBeDefined();
-  expect(GithubDataParser.getPullRequestParsedData(githubPullRequestJson, githubPullRequestFilesJson)).toEqual(expectedJson);
+  expect(GithubDataParser.getPullRequestParsedData(githubPullRequestJson, githubPullRequestFilesJson, githubReviewersDataJson)).toEqual(expectedJson);
 })

--- a/src/github/github-data-parser.js
+++ b/src/github/github-data-parser.js
@@ -1,5 +1,5 @@
 class GithubDataParser {
-  getPullRequestParsedData(webhookData, changedFilesData) {
+  getPullRequestParsedData(webhookData, changedFilesData, reviewersData) {
     return {
       data: {
         owner: webhookData.head.repo.owner.login,
@@ -9,8 +9,8 @@ class GithubDataParser {
         user: webhookData.user.login,
         created_at: webhookData.created_at,
         merged_at: webhookData.merged_at,
-        reviewers: JSON.stringify({ reviewers: webhookData.requested_reviewers }),
-        labels: JSON.stringify({ labels: webhookData.labels }),
+        reviewers: JSON.stringify({ reviewers: this._parseReviewers(reviewersData) }),
+        labels: JSON.stringify({ labels: this._parseLabels(webhookData.labels) }),
         changed_files: JSON.stringify({ 'files': this._parseChangedFiles(changedFilesData) })
       },
       details: {
@@ -26,6 +26,22 @@ class GithubDataParser {
 
   _parseChangedFiles(fileResult) {
     return fileResult.data.map(changedFile => changedFile.filename);
+  }
+
+  _parseReviewers(reviewersData) {
+    let reviewers = [];
+
+    reviewersData.data.filter((reviewerData) => {
+      if (!(reviewers.includes(reviewerData.user.login))) {
+        reviewers.push(reviewerData.user.login);
+      }
+    });
+
+    return reviewers;
+  }
+
+  _parseLabels(labelsData) {
+    return labelsData.map(label => label.name);
   }
 }
 

--- a/src/handlers/upload-pull-request.js
+++ b/src/handlers/upload-pull-request.js
@@ -18,9 +18,10 @@ const s3 = new aws.S3();
 module.exports.uploadPullRequest = async (event) => {
   const { path: { owner, repo, number } } = event;
 
+  const pullRequestReviewers = await octokit.pullRequests.getReviews({owner, repo, number});
   const pullRequestDataResult = await octokit.pullRequests.get({ owner, repo, number });
   const pullRequestFilesData = await GithubFileRequest.getPullRequestFiles(octokit, owner, repo, number);
-  const githubJson = await GithubDataParser.getPullRequestParsedData(pullRequestDataResult.data, pullRequestFilesData);
+  const githubJson = await GithubDataParser.getPullRequestParsedData(pullRequestDataResult.data, pullRequestFilesData, pullRequestReviewers);
 
   const { data, details: { state, merged } } = githubJson;
 

--- a/src/handlers/upload-webhook.js
+++ b/src/handlers/upload-webhook.js
@@ -21,8 +21,9 @@ module.exports.uploadWebhook = async (event) => {
   const owner = pull_request.head.repo.owner.login;
   const repo = repository.name;
 
+  const pullRequestReviewers = await octokit.pullRequests.getReviews({owner, repo, number});
   const pullRequestFilesData = await GithubFileRequest.getPullRequestFiles(octokit, owner, repo, number);
-  const githubJson = await GithubDataParser.getPullRequestParsedData(pull_request, pullRequestFilesData);
+  const githubJson = await GithubDataParser.getPullRequestParsedData(pull_request, pullRequestFilesData, pullRequestReviewers);
 
   const { data, details: { state, merged } } = githubJson;
 


### PR DESCRIPTION
* Começa a usar os reviewers que são conseguidos via request ao invés de usar o campo `requested_reviewers` proveniente do webhook visto que nem sempre retornava o resultado esperado
* Muda a forma como as labels são mostradas para que somente o nome seja colocado